### PR TITLE
flake: update to 1.4.3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774709303,
-        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
         "type": "github"
       },
       "original": {
@@ -25,4 +25,3 @@
   "root": "root",
   "version": 7
 }
-

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
     {
       packages = forAllSystems (pkgs:
         let
-          version = "1.4.2";
+          version = "1.4.3";
 
           pythonEnv = pkgs.python3.withPackages (ps: with ps; [
             pyqt6
@@ -138,4 +138,3 @@
       });
     };
 }
-


### PR DESCRIPTION
## Summary
- update the flake version to 1.4.3
- refresh flake.lock to the current nixos-unstable input

## Testing performed
- nix flake check
- nix run