### PR TITLE
Fix Windows startup crash when opening near tray

### DIFF
--- a/ui/dashboard.py
+++ b/ui/dashboard.py
@@ -1325,19 +1325,18 @@ class Dashboard(QWidget):
             return
         
         self.refresh_tray_anchor()
-        target_pos = getattr(self, '_target_pos', QPoint(self.x(), self.y()))
-        
+
         # Set initial state (Hidden & Positioned) BEFORE showing
         # This prevents the window from flashing in the center/wrong place
         self.set_anim_progress(0.0)
-        
+
         # Capture frosted glass background BEFORE showing (so we grab the clean desktop)
         if self._glass_ui:
             # Position the window first so geometry is correct for capture
-            self.move(target_pos)
+            self.move(self._target_pos)
             self._glass_bg_pixmap, self._glass_capture_pos = capture_glass_background(self)
         else:
-            self.move(target_pos)
+            self.move(self._target_pos)
         
         # Ensure we are visible before animating
         super().show()


### PR DESCRIPTION
Fixes a startup crash on Windows when Prism Desktop opens near the tray.

Tested on Windows.

Fixes https://github.com/lasselian/prism-desktop/issues/14