### PR TITLE
Add a toggle command fallback for unsupported Wayland desktops

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,8 @@ import logging
 import copy
 import platform
 
+from services.local_ipc import send_local_command
+
 # Force XWayland on Wayland sessions — Qt's QWidget.move() is silently ignored
 # under native Wayland, causing the dashboard to appear centered instead of
 # anchored to the system tray corner. Must be set before QApplication is created.
@@ -28,6 +30,15 @@ logging.basicConfig(
         logging.StreamHandler(sys.stdout)
     ]
 )
+
+VERSION = "1.4.3"
+TOGGLE_ARG = "--toggle"
+
+if __name__ == '__main__' and TOGGLE_ARG in sys.argv[1:]:
+    if send_local_command("toggle"):
+        sys.exit(0)
+    print("No running Prism Desktop instance found for --toggle")
+    sys.exit(1)
 
 import qasync
 from PyQt6.QtWidgets import QApplication
@@ -44,6 +55,7 @@ from ui.dashboard import Dashboard
 from ui.tray_manager import TrayManager
 from services.notifications import NotificationManager
 from services.input_manager import InputManager
+from services.local_ipc import LocalCommandServer
 from services.mobile_app import register_mobile_app, send_location_update
 from services.location_manager import get_location
 from ui.icons import load_mdi_font
@@ -52,8 +64,6 @@ from PyQt6.QtWidgets import QMessageBox
 from PyQt6.QtGui import QDesktopServices
 from PyQt6.QtCore import QUrl
 from core.temperature_utils import normalize_temperature_unit
-
-VERSION = "1.4.3"
 
 def _create_task_safe(coro):
     """Schedule an async task safely from synchronous Qt context.
@@ -79,6 +89,7 @@ class PrismDesktopApp(QObject):
         self.ha_client = HAClient()
         self.notification_manager = NotificationManager(ha_client=self.ha_client)
         self.input_manager = InputManager()
+        self.local_command_server = LocalCommandServer(self)
         
         # UI Components
         self.dashboard: Optional[Dashboard] = None
@@ -112,6 +123,7 @@ class PrismDesktopApp(QObject):
         self.init_theme()
         self.init_ha_client()
         self.init_ui()
+        self.init_local_ipc()
         
         # Initialize shortcuts in background
         QTimer.singleShot(100, self.init_shortcuts)
@@ -140,6 +152,13 @@ class PrismDesktopApp(QObject):
         self.input_manager.update_shortcut(shortcut_config)
         self.input_manager.triggered.connect(self._toggle_dashboard)
 
+    def init_local_ipc(self):
+        """Listen for local CLI commands such as --toggle."""
+        if self.local_command_server.start():
+            self.local_command_server.command_received.connect(self._handle_local_command)
+        else:
+            logging.warning("Failed to start local Prism command server")
+
     def _tray_geometry(self) -> QRect:
         """Return the tray icon geometry when available."""
         if self.tray_manager:
@@ -150,6 +169,12 @@ class PrismDesktopApp(QObject):
         """Show the dashboard using tray geometry when Qt provides it."""
         if self.dashboard:
             self.dashboard.show_near_tray(self._tray_geometry())
+
+    @pyqtSlot(str)
+    def _handle_local_command(self, command: str):
+        """Handle a local CLI command sent to the running instance."""
+        if command == "toggle":
+            self._toggle_dashboard()
     
     def save_config(self):
         """Save configuration to file via ConfigManager."""
@@ -364,6 +389,8 @@ class PrismDesktopApp(QObject):
     def _quit(self):
         """Quit the application."""
         self.stop_all_threads()
+        if self.local_command_server:
+            self.local_command_server.close()
         QApplication.instance().quit()
     
     @pyqtSlot(dict)

--- a/services/local_ipc.py
+++ b/services/local_ipc.py
@@ -1,0 +1,82 @@
+"""
+Local IPC helpers for controlling an existing Prism Desktop instance.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from PyQt6.QtCore import QObject, pyqtSignal
+from PyQt6.QtNetwork import QLocalServer, QLocalSocket
+
+from core.utils import get_config_path
+
+
+def prism_ipc_server_name() -> str:
+    """Return a stable local server name for the current Prism config path."""
+    config_path = str(get_config_path().resolve())
+    digest = hashlib.sha1(config_path.encode("utf-8")).hexdigest()[:12]
+    return f"prism-desktop-{digest}"
+
+
+def send_local_command(command: str, timeout_ms: int = 1000) -> bool:
+    """Send a command to an already-running Prism instance."""
+    socket = QLocalSocket()
+    socket.connectToServer(prism_ipc_server_name())
+    if not socket.waitForConnected(timeout_ms):
+        return False
+
+    payload = command.strip().encode("utf-8")
+    socket.write(payload)
+    if not socket.waitForBytesWritten(timeout_ms):
+        socket.disconnectFromServer()
+        return False
+
+    socket.flush()
+    socket.disconnectFromServer()
+    return True
+
+
+class LocalCommandServer(QObject):
+    """Listen for local commands from helper Prism invocations."""
+
+    command_received = pyqtSignal(str)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._server = QLocalServer(self)
+        self._server.newConnection.connect(self._on_new_connection)
+        self._clients = set()
+
+    def start(self) -> bool:
+        """Start listening for local commands."""
+        name = prism_ipc_server_name()
+        if self._server.listen(name):
+            return True
+
+        QLocalServer.removeServer(name)
+        return self._server.listen(name)
+
+    def close(self):
+        """Stop the local command server."""
+        self._server.close()
+        QLocalServer.removeServer(prism_ipc_server_name())
+
+    def _on_new_connection(self):
+        while self._server.hasPendingConnections():
+            socket = self._server.nextPendingConnection()
+            if socket is None:
+                return
+            self._clients.add(socket)
+            socket.readyRead.connect(lambda s=socket: self._read_socket(s))
+            socket.disconnected.connect(lambda s=socket: self._drop_socket(s))
+
+    def _read_socket(self, socket: QLocalSocket):
+        raw = bytes(socket.readAll()).decode("utf-8", errors="ignore").strip()
+        if raw:
+            self.command_received.emit(raw)
+        socket.disconnectFromServer()
+
+    def _drop_socket(self, socket: QLocalSocket):
+        self._clients.discard(socket)
+        socket.deleteLater()

--- a/services/wayland_global_shortcut.py
+++ b/services/wayland_global_shortcut.py
@@ -231,10 +231,7 @@ class WaylandGlobalShortcut:
             # desktop file has not been indexed yet. Treat those cases as a
             # warning so Prism can keep using the portal path where supported.
             text = reply.body[0] if reply.body else reply.error_name
-            if (
-                reply.error_name != "org.freedesktop.DBus.Error.Failed"
-                or "App info not found" not in text
-            ):
+            if "App info not found" not in text:
                 raise RuntimeError(f"Registry.Register failed: {text}")
             logger.warning("Wayland portal app id registration skipped: %s", text)
         else:

--- a/services/wayland_global_shortcut.py
+++ b/services/wayland_global_shortcut.py
@@ -227,11 +227,16 @@ class WaylandGlobalShortcut:
             body=[APP_ID, {}],
         ))
         if reply.message_type == MessageType.ERROR:
-            # Already registered on this connection is harmless. Other errors matter.
+            # The registry helper is optional and may fail when the host app's
+            # desktop file has not been indexed yet. Treat those cases as a
+            # warning so Prism can keep using the portal path where supported.
             text = reply.body[0] if reply.body else reply.error_name
-            if reply.error_name != "org.freedesktop.DBus.Error.Failed":
+            if (
+                reply.error_name != "org.freedesktop.DBus.Error.Failed"
+                or "App info not found" not in text
+            ):
                 raise RuntimeError(f"Registry.Register failed: {text}")
-            logger.info("Wayland portal app id registration skipped: %s", text)
+            logger.warning("Wayland portal app id registration skipped: %s", text)
         else:
             logger.info("Wayland portal app id registered: %s", APP_ID)
 

--- a/ui/settings_widget.py
+++ b/ui/settings_widget.py
@@ -446,7 +446,6 @@ class SettingsWidget(QWidget):
         self.kde_shortcuts_btn.clicked.connect(self.open_kde_shortcuts)
         self.kde_shortcuts_btn.hide()
         shortcut_aux_layout.addWidget(self.kde_shortcuts_btn, 0, Qt.AlignmentFlag.AlignLeft)
-
         self.shortcut_aux.hide()
         shortcut_container_layout.addWidget(self.shortcut_aux)
         self.form.addRow("App Toggle:", shortcut_container)
@@ -639,6 +638,10 @@ class SettingsWidget(QWidget):
             self.record_btn.setChecked(False)
             return
 
+        if self._is_unsupported_wayland_shortcut_env():
+            self.record_btn.setChecked(False)
+            return
+
         if not self.input_manager:
             self.record_btn.setChecked(False)
             return
@@ -707,6 +710,7 @@ class SettingsWidget(QWidget):
             self.shortcut_display.setToolTip("")
             self.shortcut_hint.setText(
                 "Global app-toggle shortcuts are not currently supported on this Wayland desktop. "
+                "Create a custom keybind that runs 'prism-desktop --toggle' instead. "
                 "The in-window entity shortcuts still work while Prism is focused."
             )
             self.shortcut_aux.show()

--- a/ui/settings_widget.py
+++ b/ui/settings_widget.py
@@ -4,6 +4,9 @@ Settings Widget
 Clean, minimalist, and bug-free implementation of the Settings panel.
 """
 
+import os
+import shutil
+import subprocess
 import sys
 from typing import Optional
 from PyQt6.QtWidgets import (
@@ -12,7 +15,7 @@ from PyQt6.QtWidgets import (
     QGraphicsOpacityEffect, QFrame, QColorDialog
 )
 from ui.widgets.toggle_switch import ToggleSwitch
-from PyQt6.QtCore import Qt, pyqtSignal, pyqtProperty, pyqtSlot, QUrl, QProcess
+from PyQt6.QtCore import Qt, pyqtSignal, pyqtProperty, pyqtSlot, QUrl
 from PyQt6.QtGui import QFont, QColor, QDesktopServices, QIcon, QPixmap
 from core.utils import SYSTEM_FONT
 
@@ -735,13 +738,19 @@ class SettingsWidget(QWidget):
 
     def open_kde_shortcuts(self):
         """Open KDE's shortcut settings module when possible."""
-        commands = [
-            ("kcmshell6", ["kcm_keys"]),
-            ("systemsettings", ["kcm_keys"]),
-        ]
-        for program, args in commands:
-            if QProcess.startDetached(program, args):
-                return
+        # Strip AppImage library overrides so system KDE tools use their own libs.
+        env = os.environ.copy()
+        for key in ("LD_LIBRARY_PATH", "LD_PRELOAD"):
+            env.pop(key, None)
+
+        for program in ("kcmshell6", "systemsettings"):
+            exe = shutil.which(program, path=env.get("PATH"))
+            if exe:
+                try:
+                    subprocess.Popen([exe, "kcm_keys"], env=env)
+                    return
+                except OSError:
+                    continue
 
         QDesktopServices.openUrl(QUrl("settings://keyboard/shortcuts"))
 


### PR DESCRIPTION
## What this changes
This adds a simple fallback command: prism-desktop --toggle.

Instead of asking Prism to register a global shortcut itself, unsupported Wayland desktops can call this command from their own shortcut system. The running Prism instance listens for the command and toggles the window.

## Why
Some Wayland desktops do not support Prisms global app-toggle shortcut path well enough to make it reliable. In those environments, it is better to let the desktop own the keybinding and let Prism respond to a local toggle command.

This gives users a practical way to create their own shortcut in environments like GNOME or Hyprland.

## User-facing behavior
- Unsupported Wayland desktops can use a custom shortcut that runs prism-desktop --toggle
- The helper path starts quickly and talks to the already-running Prism instance
- The settings UI points unsupported Wayland users to this fallback
- Existing supported platforms keep their current shortcut behavior

## Screenshot
<img width="549" height="136" alt="Skärmbild_20260405_182541" src="https://github.com/user-attachments/assets/e6dcf85d-5c91-4ae8-822e-013f1df5270c" />
