### PR TITLE
flake: update to 1.4.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775036866,
-        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "lastModified": 1775423009,
+        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
     {
       packages = forAllSystems (pkgs:
         let
-          version = "1.4.3";
+          version = "1.4.4";
 
           pythonEnv = pkgs.python3.withPackages (ps: with ps; [
             pyqt6


### PR DESCRIPTION
## Summary
- update the flake version to 1.4.4
- refresh flake.lock to the current nixos-unstable input

## Testing performed
- nix flake check
- nix run