### PR TITLE
Set a stable Qt argv0 for KDE window matching

### DIFF
--- a/main.py
+++ b/main.py
@@ -837,7 +837,9 @@ class PrismDesktopApp(QObject):
 
 if __name__ == '__main__':
     # Bootstrap
-    app = QApplication(sys.argv)
+    qt_argv = list(sys.argv)
+    qt_argv[0] = "prism-desktop"
+    app = QApplication(qt_argv)
     app.setQuitOnLastWindowClosed(False)
     
     # Use qasync Event Loop


### PR DESCRIPTION
## Summary

- make Prism Desktop identify itself more consistently to KDE Plasma
- stop Plasma from showing main.py as the app/window identity

## Why

KDE Plasma was seeing the app as main.py instead of Prism Desktop. That made window rules and app matching confusing and harder to use, and could affect other windows since it was not a unique string. This change makes the app present a stable, app-specific identity so Plasma can recognize it properly.

## Pre-fix
<img width="703" height="752" alt="Skärmbild_20260407_114904" src="https://github.com/user-attachments/assets/3c7e1ca9-3edb-4e0d-a3af-e0aaa51ff20a" />

## Post-fix
<img width="739" height="738" alt="Skärmbild_20260407_121554" src="https://github.com/user-attachments/assets/4e82950a-169f-4ace-a4bf-3889cd9c65b0" />

## Windows
App builds and runs without any obvious issues.