### PR TITLE
flake: bump to v1.5

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775423009,
-        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
     {
       packages = forAllSystems (pkgs:
         let
-          version = "1.4.4";
+          version = "1.5";
 
           pythonEnv = pkgs.python3.withPackages (ps: with ps; [
             pyqt6
@@ -42,7 +42,7 @@
               owner = "lasselian";
               repo = "prism-desktop";
               rev = version;
-              hash = "sha256-jgiQveKhzvFnb52oy4AWj+C12S7yW9d9z1MHU9Fy7xM=";
+              hash = "sha256-G+RFAieoNOn1H98W3DCX5bYWQxBjJppufpI+Msc9kBQ=";
             };
 
             nativeBuildInputs = [


### PR DESCRIPTION
Bumps the Nix flake from v1.4.4 to v1.5 and updates the source hash accordingly.