### PR TITLE
flake: fix buildCommit hash for v1.5

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       forAllSystems = f:
         nixpkgs.lib.genAttrs systems
           (system: f (import nixpkgs { inherit system; }));
-      buildCommit = "c25c22aaf16e";
+      buildCommit = "fc29f6c84a90";
       buildDirty = false;
     in
     {


### PR DESCRIPTION
## Summary

- `buildCommit` was set to `c25c22aaf16e`, which is incorrect for the `1.5` tag
- The `1.5` tag resolves to `fc29f6c84a90`

This is a purely visual bug — `buildCommit` is only used to populate `BUILD_COMMIT` in `_generated_build_info.py`, which is displayed as build info in the app. It has no effect on the build or runtime behaviour.