### PR TITLE
flake: update to 1.5.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776877367,
-        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,13 +11,13 @@
       forAllSystems = f:
         nixpkgs.lib.genAttrs systems
           (system: f (import nixpkgs { inherit system; }));
-      buildCommit = "fc29f6c84a90";
+      buildCommit = "11359abaa551";
       buildDirty = false;
     in
     {
       packages = forAllSystems (pkgs:
         let
-          version = "1.5";
+          version = "1.5.1";
 
           pythonEnv = pkgs.python3.withPackages (ps: with ps; [
             pyqt6
@@ -42,7 +42,7 @@
               owner = "lasselian";
               repo = "prism-desktop";
               rev = version;
-              hash = "sha256-G+RFAieoNOn1H98W3DCX5bYWQxBjJppufpI+Msc9kBQ=";
+              hash = "sha256-UUXgwB5g8rzWwMs6vo6F/4KCnqNTGCMmEPjg2v7Fcuw=";
             };
 
             nativeBuildInputs = [
@@ -102,7 +102,7 @@
               runHook preInstall
 
               mkdir -p $out/share/prism-desktop
-              cp -r core services ui $out/share/prism-desktop/
+              cp -r core services ui translations $out/share/prism-desktop/
               cp main.py icon.png materialdesignicons-webfont.ttf mdi_mapping.json \
                 LICENSE README.md \
                 $out/share/prism-desktop/


### PR DESCRIPTION
## Summary
- update the flake version to 1.5.1
- refresh flake.lock to the current nixos-unstable input
- add translations to $out/share/prism-desktop

## Testing performed
- nix flake check
- nix run