### PR TITLE
fix: bundle MDI mapping in release and refresh buttons after background fetch

### DIFF
--- a/build_exe.py
+++ b/build_exe.py
@@ -46,6 +46,11 @@ def build():
     build_dir = base_dir / "build"
     icon_path = base_dir / "icon.png"
     font_path = base_dir / "materialdesignicons-webfont.ttf"
+
+    # Ensure MDI mapping is present so it gets bundled (required for offline users)
+    from generate_mdi_mapping import generate as generate_mdi_mapping
+    if not generate_mdi_mapping():
+        print("Warning: mdi_mapping.json could not be generated — icons may not work offline.")
     
     # Clean previous builds
     if dist_dir.exists():
@@ -80,7 +85,6 @@ def build():
         else:
             cmd.extend(["--icon", str(icon_path)])
         
-    # Add cached mapping if exists
     mapping_path = base_dir / "mdi_mapping.json"
     if mapping_path.exists():
         cmd.extend(["--add-data", f"{mapping_path};."])

--- a/build_linux.py
+++ b/build_linux.py
@@ -99,6 +99,12 @@ def find_appimagetool(arch):
 
 def build_binary(base_dir):
     """Build the standalone binary using PyInstaller in a clean virtual environment."""
+    # Ensure MDI mapping is present so it gets bundled (required for offline users)
+    sys.path.insert(0, str(base_dir))
+    from generate_mdi_mapping import generate as generate_mdi_mapping
+    if not generate_mdi_mapping():
+        print("Warning: mdi_mapping.json could not be generated — icons may not work offline.")
+
     venv_dir = base_dir / '.build_venv'
     
     print("Setting up clean virtual environment...")

--- a/generate_mdi_mapping.py
+++ b/generate_mdi_mapping.py
@@ -1,0 +1,48 @@
+"""
+Generate mdi_mapping.json from the MDI CSS file.
+
+Run this script once before building to ensure the mapping is bundled
+in the release. Both build_exe.py and build_linux.py call this automatically.
+"""
+
+import json
+import re
+import ssl
+import sys
+import urllib.request
+from pathlib import Path
+
+MDI_CSS_URL = (
+    "https://raw.githubusercontent.com/Templarian/"
+    "MaterialDesign-Webfont/master/css/materialdesignicons.css"
+)
+OUTPUT = Path(__file__).parent / "mdi_mapping.json"
+
+
+def generate(force: bool = False) -> bool:
+    if OUTPUT.exists() and not force:
+        print(f"mdi_mapping.json already exists ({OUTPUT}), skipping.")
+        return True
+    try:
+        print("Fetching MDI icon mapping from GitHub...")
+        context = ssl._create_unverified_context()
+        with urllib.request.urlopen(MDI_CSS_URL, context=context, timeout=30) as resp:
+            css = resp.read().decode("utf-8")
+
+        pattern = re.compile(
+            r'\.mdi-([a-z0-9-]+)::?before\s*\{\s*content:\s*"\\([0-9a-f]+)"',
+            re.IGNORECASE,
+        )
+        mapping = {m.group(1): chr(int(m.group(2), 16)) for m in pattern.finditer(css)}
+
+        OUTPUT.write_text(json.dumps(mapping, ensure_ascii=False), encoding="utf-8")
+        print(f"Saved {len(mapping)} icons to {OUTPUT}")
+        return True
+    except Exception as exc:
+        print(f"ERROR: Failed to generate MDI mapping: {exc}", file=sys.stderr)
+        return False
+
+
+if __name__ == "__main__":
+    force = "--force" in sys.argv
+    sys.exit(0 if generate(force=force) else 1)

--- a/main.py
+++ b/main.py
@@ -63,7 +63,7 @@ from services.input_manager import InputManager, ButtonShortcutManager
 from services.local_ipc import LocalCommandServer
 from services.mobile_app import register_mobile_app, send_location_update, register_sensors, update_sensor_states, build_sensor_state_payload, SENSORS as MOBILE_APP_SENSORS
 from services.location_manager import get_location
-from ui.icons import load_mdi_font
+from ui.icons import load_mdi_font, icon_signals
 from services.update_checker import UpdateCheckerThread
 from PyQt6.QtGui import QDesktopServices
 from PyQt6.QtCore import QUrl
@@ -157,6 +157,9 @@ class PrismDesktopApp(QObject):
         # Welcome banner on first launch
         self._welcome_banner = None
         QTimer.singleShot(800, self._maybe_show_welcome)
+
+        # Refresh buttons once the MDI mapping finishes loading in the background
+        icon_signals.mapping_loaded.connect(self._on_mdi_mapping_loaded)
 
         # Check for updates
         QTimer.singleShot(2000, self.check_for_updates)
@@ -1086,6 +1089,15 @@ class PrismDesktopApp(QObject):
                     self.dashboard.update_media_art(entity_id, pixmap)
 
 
+
+    @pyqtSlot()
+    def _on_mdi_mapping_loaded(self):
+        if self.dashboard and self.dashboard._all_button_configs:
+            self.dashboard.set_buttons(
+                self.dashboard._all_button_configs,
+                self.dashboard.config.get('appearance', {}),
+                update_height=False,
+            )
 
     def check_for_updates(self):
         """Check for updates in background; runs the post-update sanity check when a flag is present."""

--- a/ui/icons.py
+++ b/ui/icons.py
@@ -8,6 +8,7 @@ import json
 import re
 import urllib.request
 import ssl
+from PyQt6.QtCore import QObject, pyqtSignal
 from PyQt6.QtGui import QFontDatabase, QFont
 from core.utils import get_resource_path, get_config_path
 
@@ -16,6 +17,12 @@ MDI_FONT_FAMILY = "Material Design Icons"
 
 # Flag to track if font is loaded
 _font_loaded = False
+
+
+class _IconSignals(QObject):
+    mapping_loaded = pyqtSignal()
+
+icon_signals = _IconSignals()
 
 def load_mdi_font():
     """Load the MDI font into the application. Call once at startup."""
@@ -203,6 +210,7 @@ def fetch_mdi_mapping_worker():
             
         print(f"Saved {len(mapping)} icons to {mapping_file}")
         _mdi_cache = mapping
+        icon_signals.mapping_loaded.emit()
     except Exception as e:
         print(f"Failed to fetch MDI mapping: {e}")
     finally:


### PR DESCRIPTION
Fixes #37

## Problem
Two related causes for `mdi:` icons showing as blank placeholders:

1. **Windows 10 (no redraw)** — the MDI icon mapping is fetched from GitHub in a background thread on first launch. The fetch completed successfully but nothing triggered the buttons to redraw, so placeholders stayed permanently. More likely to hit on Win10 where startup is slower.

2. **Restricted networks** — users behind firewalls that block `raw.githubusercontent.com` never get the mapping at all, so icons never load regardless of OS.

## Changes
- Added a `mapping_loaded` signal to `icon_signals` that fires after the background fetch completes, connected to a `set_buttons` refresh on the dashboard — fixes the no-redraw issue
- Added `generate_mdi_mapping.py`, a standalone script that fetches and saves the mapping
- Both `build_exe.py` and `build_linux.py` now run this script automatically before packaging, so `mdi_mapping.json` is always bundled in the release — fixes the network issue