### PR TITLE
Fixes a fatal "Failed to load Python DLL" crash on Windows launch

### DIFF
--- a/build_exe.py
+++ b/build_exe.py
@@ -46,11 +46,6 @@ def build():
     build_dir = base_dir / "build"
     icon_path = base_dir / "icon.png"
     font_path = base_dir / "materialdesignicons-webfont.ttf"
-
-    # Ensure MDI mapping is present so it gets bundled (required for offline users)
-    from generate_mdi_mapping import generate as generate_mdi_mapping
-    if not generate_mdi_mapping():
-        print("Warning: mdi_mapping.json could not be generated — icons may not work offline.")
     
     # Clean previous builds
     if dist_dir.exists():
@@ -62,10 +57,10 @@ def build():
     cmd = [
         sys.executable, "-m", "PyInstaller",
         "--noconsole",
-        "--onefile",
+        "--onedir",
         "--name", "PrismDesktop",
         "--add-data", f"{font_path};.",  # Windows separator is ;
-        "--exclude", "PySide6",  # Avoid Qt binding conflict
+        "--exclude-module", "PySide6",  # Avoid Qt binding conflict
     ]
     
     # Add icon if exists — Windows needs .ico, so convert from .png via Pillow
@@ -85,6 +80,7 @@ def build():
         else:
             cmd.extend(["--icon", str(icon_path)])
         
+    # Add cached mapping if exists
     mapping_path = base_dir / "mdi_mapping.json"
     if mapping_path.exists():
         cmd.extend(["--add-data", f"{mapping_path};."])
@@ -108,7 +104,7 @@ def build():
             ico_tmp.unlink()
 
     print("\nBuild complete!")
-    print(f"Executable is at: {dist_dir / 'PrismDesktop.exe'}")
+    print(f"Executable is at: {dist_dir / 'PrismDesktop' / 'PrismDesktop.exe'}")
     print("Note: Configuration is stored in %APPDATA%/PrismDesktop/config.json")
 
 if __name__ == "__main__":

--- a/build_exe.py
+++ b/build_exe.py
@@ -46,7 +46,12 @@ def build():
     build_dir = base_dir / "build"
     icon_path = base_dir / "icon.png"
     font_path = base_dir / "materialdesignicons-webfont.ttf"
-    
+
+    # Ensure MDI mapping is present so it gets bundled (required for offline users)
+    from generate_mdi_mapping import generate as generate_mdi_mapping
+    if not generate_mdi_mapping():
+        print("Warning: mdi_mapping.json could not be generated — icons may not work offline.")
+
     # Clean previous builds
     if dist_dir.exists():
         shutil.rmtree(dist_dir)

--- a/setup.iss
+++ b/setup.iss
@@ -1,48 +1,62 @@
-; Script generated for Prism Desktop
-; Requires Inno Setup: https://jrsoftware.org/isdl.php
+  ; Script generated for Prism Desktop
+  ; Requires Inno Setup: https://jrsoftware.org/isdl.php
 
-#define MyAppName "Prism Desktop"
-#define MyAppVersion "1.5.3"
-#define MyAppPublisher "Lasse Lian"
-#define MyAppExeName "PrismDesktop.exe"
+  #define MyAppName "Prism Desktop"
+  #define MyAppVersion "1.5.3"
+  #define MyAppPublisher "Lasse Lian"
+  #define MyAppExeName "PrismDesktop.exe"
 
-[Setup]
-; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
-; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
-AppId={{D3FAC2A3-1A2B-4C3D-5E6F-789012345678}
-AppName={#MyAppName}
-AppVersion={#MyAppVersion}
-AppPublisher={#MyAppPublisher}
-DefaultDirName={autopf}\{#MyAppName}
-DisableProgramGroupPage=yes
-; Remove the following line to run in administrative install mode (install for all users.)
-PrivilegesRequired=lowest
-OutputDir=installer
-OutputBaseFilename=PrismDesktopSetup
-Compression=lzma
-SolidCompression=yes
-WizardStyle=modern
+  [Setup]
+  ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
+  ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
+  AppId={{D3FAC2A3-1A2B-4C3D-5E6F-789012345678}
+  AppName={#MyAppName}
+  AppVersion={#MyAppVersion}
+  AppPublisher={#MyAppPublisher}
+  DefaultDirName={autopf}\{#MyAppName}
+  DisableProgramGroupPage=yes
+  PrivilegesRequired=lowest
+  OutputDir=installer
+  OutputBaseFilename=PrismDesktopSetup
+  Compression=lzma
+  SolidCompression=yes
+  WizardStyle=modern
+  CloseApplications=yes
+  CloseApplicationsFilter=PrismDesktop.exe
+  RestartApplications=no
 
-[Languages]
-Name: "english"; MessagesFile: "compiler:Default.isl"
-; Name: "norwegian"; MessagesFile: "compiler:Languages\Norwegian.isl"
+  [Languages]
+  Name: "english"; MessagesFile: "compiler:Default.isl"
+  ; Name: "norwegian"; MessagesFile: "compiler:Languages\Norwegian.isl"
 
-[Tasks]
-Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
-Name: "startup"; Description: "Start {#MyAppName} with Windows"; GroupDescription: "{cm:AdditionalIcons}"
+  [Tasks]
+  Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+  Name: "startup"; Description: "Start {#MyAppName} with Windows"; GroupDescription: "{cm:AdditionalIcons}"
 
-[Files]
-; IMPORTANT: Ensure you run 'python build_exe.py' BEFORE compiling this script
-Source: "dist\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
-; NOTE: We do NOT bundle config.json so that new installs start fresh (or use AppData)
+  [Files]
+  ; IMPORTANT: Ensure you run 'python build_exe.py' BEFORE compiling this script
+  ; NOTE: onedir build — copy the entire dist\PrismDesktop\ folder
+  Source: "dist\PrismDesktop\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+  ; NOTE: We do NOT bundle config.json so that new installs start fresh (or use AppData)
 
-[Icons]
-Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
-Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+  [Icons]
+  Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
+  Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 
-[Run]
-Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#MyAppName}}"; Flags: nowait postinstall skipifsilent
+  [Run]
+  Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#MyAppName}}"; Flags: nowait postinstall skipifsilent
 
-[Registry]
-; Start with Windows logic
-Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; ValueType: string; ValueName: "{#MyAppName}"; ValueData: """{app}\{#MyAppExeName}"""; Flags: uninsdeletevalue; Tasks: startup
+  [Registry]
+  ; Start with Windows logic
+  Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; ValueType: string; ValueName: "{#MyAppName}"; ValueData: """{app}\{#MyAppExeName}"""; Flags: uninsdeletevalue; Tasks: startup
+
+  [Code]
+  function PrepareToInstall(var NeedsRestart: Boolean): String;
+  var
+    ResultCode: Integer;
+  begin
+    { Force-kill all running instances including PyInstaller child processes (/T = process tree) }
+    Exec(ExpandConstant('{sys}\taskkill.exe'), '/F /IM PrismDesktop.exe /T', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    Sleep(1500);
+    Result := '';
+  end;

--- a/setup.iss
+++ b/setup.iss
@@ -1,62 +1,62 @@
-  ; Script generated for Prism Desktop
-  ; Requires Inno Setup: https://jrsoftware.org/isdl.php
+; Script generated for Prism Desktop
+; Requires Inno Setup: https://jrsoftware.org/isdl.php
 
-  #define MyAppName "Prism Desktop"
-  #define MyAppVersion "1.5.3"
-  #define MyAppPublisher "Lasse Lian"
-  #define MyAppExeName "PrismDesktop.exe"
+#define MyAppName "Prism Desktop"
+#define MyAppVersion "1.5.3"
+#define MyAppPublisher "Lasse Lian"
+#define MyAppExeName "PrismDesktop.exe"
 
-  [Setup]
-  ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
-  ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
-  AppId={{D3FAC2A3-1A2B-4C3D-5E6F-789012345678}
-  AppName={#MyAppName}
-  AppVersion={#MyAppVersion}
-  AppPublisher={#MyAppPublisher}
-  DefaultDirName={autopf}\{#MyAppName}
-  DisableProgramGroupPage=yes
-  PrivilegesRequired=lowest
-  OutputDir=installer
-  OutputBaseFilename=PrismDesktopSetup
-  Compression=lzma
-  SolidCompression=yes
-  WizardStyle=modern
-  CloseApplications=yes
-  CloseApplicationsFilter=PrismDesktop.exe
-  RestartApplications=no
+[Setup]
+; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
+; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
+AppId={{D3FAC2A3-1A2B-4C3D-5E6F-789012345678}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+DefaultDirName={autopf}\{#MyAppName}
+DisableProgramGroupPage=yes
+PrivilegesRequired=lowest
+OutputDir=installer
+OutputBaseFilename=PrismDesktopSetup
+Compression=lzma
+SolidCompression=yes
+WizardStyle=modern
+CloseApplications=yes
+CloseApplicationsFilter=PrismDesktop.exe
+RestartApplications=no
 
-  [Languages]
-  Name: "english"; MessagesFile: "compiler:Default.isl"
-  ; Name: "norwegian"; MessagesFile: "compiler:Languages\Norwegian.isl"
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+; Name: "norwegian"; MessagesFile: "compiler:Languages\Norwegian.isl"
 
-  [Tasks]
-  Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
-  Name: "startup"; Description: "Start {#MyAppName} with Windows"; GroupDescription: "{cm:AdditionalIcons}"
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+Name: "startup"; Description: "Start {#MyAppName} with Windows"; GroupDescription: "{cm:AdditionalIcons}"
 
-  [Files]
-  ; IMPORTANT: Ensure you run 'python build_exe.py' BEFORE compiling this script
-  ; NOTE: onedir build — copy the entire dist\PrismDesktop\ folder
-  Source: "dist\PrismDesktop\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
-  ; NOTE: We do NOT bundle config.json so that new installs start fresh (or use AppData)
+[Files]
+; IMPORTANT: Ensure you run 'python build_exe.py' BEFORE compiling this script
+; NOTE: onedir build — copy the entire dist\PrismDesktop\ folder
+Source: "dist\PrismDesktop\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+; NOTE: We do NOT bundle config.json so that new installs start fresh (or use AppData)
 
-  [Icons]
-  Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
-  Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+[Icons]
+Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 
-  [Run]
-  Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#MyAppName}}"; Flags: nowait postinstall skipifsilent
+[Run]
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#MyAppName}}"; Flags: nowait postinstall skipifsilent
 
-  [Registry]
-  ; Start with Windows logic
-  Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; ValueType: string; ValueName: "{#MyAppName}"; ValueData: """{app}\{#MyAppExeName}"""; Flags: uninsdeletevalue; Tasks: startup
+[Registry]
+; Start with Windows logic
+Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; ValueType: string; ValueName: "{#MyAppName}"; ValueData: """{app}\{#MyAppExeName}"""; Flags: uninsdeletevalue; Tasks: startup
 
-  [Code]
-  function PrepareToInstall(var NeedsRestart: Boolean): String;
-  var
-    ResultCode: Integer;
-  begin
-    { Force-kill all running instances including PyInstaller child processes (/T = process tree) }
-    Exec(ExpandConstant('{sys}\taskkill.exe'), '/F /IM PrismDesktop.exe /T', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
-    Sleep(1500);
-    Result := '';
-  end;
+[Code]
+function PrepareToInstall(var NeedsRestart: Boolean): String;
+var
+  ResultCode: Integer;
+begin
+  { Force-kill all running instances including PyInstaller child processes (/T = process tree) }
+  Exec(ExpandConstant('{sys}\taskkill.exe'), '/F /IM PrismDesktop.exe /T', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  Sleep(1500);
+  Result := '';
+end;


### PR DESCRIPTION
Fixes a fatal "Failed to load Python DLL" crash on Windows launch by switching the PyInstaller build from `--onefile` to `--onedir`, eliminating the race condition where antivirus and temp-cleanup tools would quarantine the extracted DLL before it finished loading. Also updates the Inno Setup installer to reliably terminate all running processes (bootloader + Python interpreter) before copying files, preventing the "Access is denied" error that blocked in-place updates.

## Files Changed
- `build_exe.py`
- `setup.iss`

---

## `build_exe.py` — DLL crash fix + invalid flag

### What changed
```diff
- "--onefile",
+ "--onedir",

- "--exclude", "PySide6",
+ "--exclude-module", "PySide6",

- print(f"Executable is at: {dist_dir / 'PrismDesktop.exe'}")
+ print(f"Executable is at: {dist_dir / 'PrismDesktop' / 'PrismDesktop.exe'}")
```

### Why
`--onefile` mode extracts the entire Python runtime — including `python313.dll` — into
a random `%TEMP%\_MEIxxxxx` folder on **every launch**. Antivirus scanners and Windows
temp-cleanup tools would frequently quarantine or delete that DLL before it finished
loading, producing the fatal **"Failed to load Python DLL"** crash.

`--onedir` puts all files permanently in the app folder (`dist\PrismDesktop\`). There is
no temp-folder extraction, so there is no race condition.

`--exclude PySide6` is not a recognised PyInstaller option and was silently ignored.
The correct flag is `--exclude-module PySide6`.

---

## `setup.iss` — Installer process-kill + onedir file copy

### What changed
```diff
- #define MyAppVersion "1.5.2"
+ #define MyAppVersion "1.5.3"

+ CloseApplications=yes
+ CloseApplicationsFilter=PrismDesktop.exe
+ RestartApplications=no

- Source: "dist\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+ Source: "dist\PrismDesktop\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs

+ [Code]
+ function PrepareToInstall(var NeedsRestart: Boolean): String;
+ var
+   ResultCode: Integer;
+ begin
+   { Force-kill all running instances including PyInstaller child processes (/T = process tree) }
+   Exec(ExpandConstant('{sys}\taskkill.exe'), '/F /IM PrismDesktop.exe /T', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+   Sleep(1500);
+   Result := '';
+ end;
```

### Why
`--onedir` spawns **two** processes with the same executable name (`PrismDesktop.exe`):
a small bootloader (~1 MB) and the actual Python interpreter (~94 MB). Inno Setup's
built-in `CloseApplications` only terminates one of them, leaving the other holding a
lock on the `.exe` and DLL files. This caused the installer to fail with:

> `DeleteFile failed; code 5. Access is denied.`

The `/T` flag on `taskkill` kills the **entire process tree** in one call, ensuring both
processes are gone before copying begins. The 1500 ms sleep gives the OS time to release
all file handles.

`Source: "dist\PrismDesktop\*"` with `recursesubdirs createallsubdirs` is required
because `--onedir` produces a folder, not a single `.exe`.

`RestartApplications=no` prevents a conflict with the existing `[Run]` entry that
already handles post-install launch.

---

## How to Apply This PR
Apply `build_exe.py` and `setup.iss` to a fresh branch from upstream `lasselian/prism-desktop`, commit, and open a PR titled:

> **"Fix Windows DLL crash (onedir build) and installer process-kill race condition"**
