### PR TITLE
flake: update to 1.5.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779357205,
-        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       forAllSystems = f:
         nixpkgs.lib.genAttrs systems
           (system: f (import nixpkgs { inherit system; }));
-      buildCommit = "53d9b2fab954";
+      buildCommit = "6ad8bda28c30";
       buildDirty = false;
     in
     {

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
             pillow
             pynput
             requests
+            psutil
             keyring
             cryptography
             secretstorage

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
     {
       packages = forAllSystems (pkgs:
         let
-          version = "1.5.3";
+          version = "1.5.4";
 
           pythonEnv = pkgs.python3.withPackages (ps: with ps; [
             pyqt6
@@ -42,7 +42,7 @@
               owner = "lasselian";
               repo = "prism-desktop";
               rev = version;
-              hash = "sha256-2xKMSXte8mAMme0CxUw8dhUwc86ig0JBhvp3LoDtVA4=";
+              hash = "sha256-SSiaU8hvJrc4nol6oHyuu2OKsKkK72LNrolFh/JTfP4=";
             };
 
             nativeBuildInputs = [


### PR DESCRIPTION
## Summary

- update the flake version to 1.5.4
- refresh flake.lock to the current nixos-unstable input

## Testing performed

- nix flake check