### PR TITLE
flake: update to 1.5.5

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780749050,
-        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,13 +11,13 @@
       forAllSystems = f:
         nixpkgs.lib.genAttrs systems
           (system: f (import nixpkgs { inherit system; }));
-      buildCommit = "6ad8bda28c30";
+      buildCommit = "f959bd6383a3";
       buildDirty = false;
     in
     {
       packages = forAllSystems (pkgs:
         let
-          version = "1.5.4";
+          version = "1.5.5";
 
           pythonEnv = pkgs.python3.withPackages (ps: with ps; [
             pyqt6
@@ -43,7 +43,7 @@
               owner = "lasselian";
               repo = "prism-desktop";
               rev = version;
-              hash = "sha256-SSiaU8hvJrc4nol6oHyuu2OKsKkK72LNrolFh/JTfP4=";
+              hash = "sha256-y13CF1IJh+ZML7jMZo35SWxi+wjYBXgPyGF2Opl1eGw=";
             };
 
             nativeBuildInputs = [


### PR DESCRIPTION
## Summary

- update the flake version to 1.5.5
- refresh flake.lock to the current nixos-unstable input

## Testing performed

- nix flake check